### PR TITLE
Try checking out a ref other than the default

### DIFF
--- a/.github/workflows/pr_close_repro.yml
+++ b/.github/workflows/pr_close_repro.yml
@@ -25,6 +25,10 @@ jobs:
         id: version # this is used on variable path
       - name: Add a git commit
         run: |
+          # Remove the merge commit from history:
+          git show HEAD^
+          git reset --hard HEAD^
+
           echo "hi there" >> added-file
           git add added-file
           git commit -m "Say 'hi there'"


### PR DESCRIPTION
This tries to check out a ref other than `github.ref` if running in a pull request context, opting to instead use the parent commit (which isn't a merge that brings the main branch into the line of commits).

(editing 3 to trigger the workflow)